### PR TITLE
Don't require clientAuth for code grant

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -74,7 +74,9 @@ OAuth2Server.prototype.token = function(request, response, options, callback) {
     accessTokenLifetime: 60 * 60,             // 1 hour.
     refreshTokenLifetime: 60 * 60 * 24 * 14,  // 2 weeks.
     allowExtendedTokenAttributes: false,
-    requireClientAuthentication: {}           // defaults to true for all grant types
+    requireClientAuthentication: {
+      authorization_code: false
+    }           // defaults to true for all grant types
   }, this.options, options);
 
   return new TokenHandler(options)


### PR DESCRIPTION
This fixes https://github.com/ging/fiware-idm/issues/167

This allows me to to acess the token endpoint when using an authorization code grant without a client secret. This is necessary for web apps.
